### PR TITLE
Style: 일부 theme variable 수정

### DIFF
--- a/packages/tailwind-config/theme/colors.css
+++ b/packages/tailwind-config/theme/colors.css
@@ -17,7 +17,7 @@
     --color-gray-13: #ffffff;
 
     /* Line Color */
-    --border-color-gray-light: #f7f7fb;
+    --border-color-gray-light: #f1f1f5;
     --border-color-gray-regular: #e5e5ec;
     --border-color-disabled: #cacad7;
 

--- a/packages/tailwind-config/theme/colors.css
+++ b/packages/tailwind-config/theme/colors.css
@@ -31,7 +31,10 @@
 
 @layer theme {
     :root {
-        /* Button & Background Color */
+        /* Text */
+        --color-text-disabled: #afafaf;
+
+        /* Button & Background */
         --color-btn-bg-light: #f7f7fb;
         --color-btn-bg-regular: #f1f1f5;
         --color-btn-bg-disabled: #cccccc;
@@ -44,7 +47,7 @@
 
     --text-color-gray-dark: var(--color-gray-03);
     --text-color-gray-regular: var(--color-gray-05);
-    --text-color-disabled: #afafaf;
+    --text-color-disabled: var(--color-text-disabled);
 
     --background-color-gray-light: var(--color-btn-bg-light);
     --background-color-gray-regular: var(--color-btn-bg-regular);

--- a/packages/tailwind-config/theme/colors.css
+++ b/packages/tailwind-config/theme/colors.css
@@ -17,24 +17,40 @@
     --color-gray-13: #ffffff;
 
     /* Line Color */
-    --color-line-light: #f7f7fb;
-    --color-line-regular: #e5e5ec;
-    --color-line-disabled: #cacad7;
-
-    /* Button & Background Color */
-    --color-btn-bg-light: #f7f7fb;
-    --color-btn-bg-regular: #f1f1f5;
-    --color-btn-bg-disabled: #cccccc;
+    --border-color-light: #f7f7fb;
+    --border-color-regular: #e5e5ec;
+    --border-color-disabled: #cacad7;
 
     /* Status Color */
     --color-status-red: #ff3d40;
     --color-status-blue: #247eed;
 
     /* Point Color */
-    --color-point-base: #ff5a2d;
+    --color-point: #ff5a2d;
+}
+
+@layer theme {
+    :root {
+        /* Button & Background Color */
+        --color-btn-bg-light: #f7f7fb;
+        --color-btn-bg-regular: #f1f1f5;
+        --color-btn-bg-disabled: #cccccc;
+    }
 }
 
 @theme inline {
     --color-black: var(--color-gray-01);
     --color-white: var(--color-gray-13);
+
+    --text-color-dark: var(--color-gray-03);
+    --text-color-regular: var(--color-gray-05);
+    --text-color-disabled: #afafaf;
+
+    --background-color-light: var(--color-btn-bg-light);
+    --background-color-regular: var(--color-btn-bg-regular);
+    --background-color-disabled: var(--color-btn-bg-disabled);
+
+    --color-button-light: var(--color-btn-bg-light);
+    --color-button-regular: var(--color-btn-bg-regular);
+    --color-button-disabled: var(--color-btn-bg-disabled);
 }

--- a/packages/tailwind-config/theme/colors.css
+++ b/packages/tailwind-config/theme/colors.css
@@ -48,7 +48,6 @@
 
     --background-color-gray-light: var(--color-btn-bg-light);
     --background-color-gray-regular: var(--color-btn-bg-regular);
-    --background-color-disabled: var(--color-btn-bg-disabled);
 
     --color-button-gray-light: var(--color-btn-bg-light);
     --color-button-gray-regular: var(--color-btn-bg-regular);

--- a/packages/tailwind-config/theme/colors.css
+++ b/packages/tailwind-config/theme/colors.css
@@ -17,8 +17,8 @@
     --color-gray-13: #ffffff;
 
     /* Line Color */
-    --border-color-light: #f7f7fb;
-    --border-color-regular: #e5e5ec;
+    --border-color-gray-light: #f7f7fb;
+    --border-color-gray-regular: #e5e5ec;
     --border-color-disabled: #cacad7;
 
     /* Status Color */
@@ -42,15 +42,15 @@
     --color-black: var(--color-gray-01);
     --color-white: var(--color-gray-13);
 
-    --text-color-dark: var(--color-gray-03);
-    --text-color-regular: var(--color-gray-05);
+    --text-color-gray-dark: var(--color-gray-03);
+    --text-color-gray-regular: var(--color-gray-05);
     --text-color-disabled: #afafaf;
 
-    --background-color-light: var(--color-btn-bg-light);
-    --background-color-regular: var(--color-btn-bg-regular);
+    --background-color-gray-light: var(--color-btn-bg-light);
+    --background-color-gray-regular: var(--color-btn-bg-regular);
     --background-color-disabled: var(--color-btn-bg-disabled);
 
-    --color-button-light: var(--color-btn-bg-light);
-    --color-button-regular: var(--color-btn-bg-regular);
+    --color-button-gray-light: var(--color-btn-bg-light);
+    --color-button-gray-regular: var(--color-btn-bg-regular);
     --color-button-disabled: var(--color-btn-bg-disabled);
 }

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -1,1 +1,0 @@
-@import 'tailwindcss';


### PR DESCRIPTION
2025.06.10. 09:29 수정
## ✨ PR Content

- **세부 namespace 적용**
>`--border-color-*` -> `border-light` `border-regular` `border-disabled`
`--text-color-*` -> `text-dark` `text-regular` `text-disabled`
`--color-button-*` -> `bg-button-light` `border-button-regular` ...
`--background-color-*` -> `bg-light` `bg-regular` `bg-disabled`

## 📎 Related Issue

- #3 

## 📸 Screenshot

- .

## 🪄 To Reviewers

말씀드린 대로 `--color-btn-bg-*` 변수는 실제 유틸리티 클래스로는 사용하지 않아 css variable로 분류했습니다.

수정 과정에서 `--text-color-disabled`가 grayscale에 없는 색상이라 새로 정의했습니다.
theme variable을 컴파일하여 새 theme variable로 선언하는 과정에서 미연의 충돌을 방지하고자 `@theme inline`를 사용하는 것으로 알고 있는데요, 그 의도에는 부합하지 않을 수 있지만 맥락 상 `@theme inline`에 나머지 text color와 함께 선언했습니다.
문법적인 오류는 없는 걸로 알고 있습니다!

이 점 관련해서 수정이 필요하다고 생각되시면 말씀 주세요!

추가로 point color에 base 부분 삭제했습니다. point color는 opacity로 조절되는데, `bg-point/50` 같은 형식으로 opacity를 조절할 수 있어서요! 불필요한 postfix라고 판단했습니다.

(추가)
지난번에 spacing 관련 말씀 드렸었는데 국문에도 spacing이 0으로 들어간 경우가 있더라고요!
지금처럼 기본적으로 `traking-tight` 적용하고 필요한 경우에 `traking-normal` 적용하면 될 것 같아 해당 부분은 별도 수정 없이 진행했습니다!