### PR TITLE
Fix: 브랜딩 페이지 project section 타이틀 개행 추가

### DIFF
--- a/apps/client/src/components/features/about/ProjectSection.tsx
+++ b/apps/client/src/components/features/about/ProjectSection.tsx
@@ -16,7 +16,9 @@ export default function ProjectSection() {
                     Project {project.projectTitle}
                 </div>
 
-                <div className="mb-4 font-medium">{project.title}</div>
+                <div className="mb-4 whitespace-pre-line font-medium">
+                    {project.title}
+                </div>
             </div>
 
             <div className="relative mb-6 aspect-[9/5] h-auto">


### PR DESCRIPTION
## ✨ PR Content

- 타이틀 개행 스타일링을 빼먹어서 추가했습니다 앞으로 잘 확인하고 머지하겠습니다,,,

## 📎 Related Issue

- #27 

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/fcbeceb3-7c46-4e54-b0ad-49df8443ad81)

## 🪄 To Reviewers

- 리뷰어에게 알려주고 싶은 내용이 있다면 여기에 작성해주세요!
