### PR TITLE
Feat: 주문 내역 api 연결

### DIFF
--- a/apps/client/src/app/agreement/refund/page.tsx
+++ b/apps/client/src/app/agreement/refund/page.tsx
@@ -1,0 +1,11 @@
+import RefundPolicy from '@/components/features/mypage/return-form/RefundPolicy';
+
+export default function Page() {
+    return (
+        <div>
+            <div className="px-5 py-6">
+                <RefundPolicy />
+            </div>
+        </div>
+    );
+}

--- a/apps/client/src/app/mypage/order-detail/[id]/page.tsx
+++ b/apps/client/src/app/mypage/order-detail/[id]/page.tsx
@@ -1,7 +1,6 @@
 import Divider from '@/components/features/mypage/Divider';
 import OrderPaymentSummary from '@/components/features/mypage/order-detail/OrderPaymentSummary';
 import ReceiptInformation from '@/components/features/mypage/order-detail/ReceiptInformation';
-import ProductItemByDeliveryState from '@/components/features/mypage/ProductItemByDeliveryState';
 import Header from '@/components/layouts/Header';
 
 export default async function Page({
@@ -22,8 +21,8 @@ export default async function Page({
 
             {/* 주문 상품 */}
             <div className="space-y-5 px-5 py-6">
-                <ProductItemByDeliveryState isDetailPage type="order" />
-                <ProductItemByDeliveryState isDetailPage type="order" />
+                {/* <ProductItemByDeliveryState isDetailPage type="order" />
+                <ProductItemByDeliveryState isDetailPage type="order" /> */}
             </div>
 
             <Divider />

--- a/apps/client/src/app/mypage/order-list/page.tsx
+++ b/apps/client/src/app/mypage/order-list/page.tsx
@@ -6,6 +6,7 @@ import Divider from '@/components/features/mypage/Divider';
 import NoItem from '@/components/features/mypage/list/NoItem';
 // import TabBar from '@/components/features/mypage/list/TabBar';
 import ProductItemByDeliveryState from '@/components/features/mypage/ProductItemByDeliveryState';
+import RefundPolicy from '@/components/features/mypage/return-form/RefundPolicy';
 import Header from '@/components/layouts/Header';
 // import { ORDER_LIST_TABS } from '@/constants/mypage';
 import { useOrderHistoryQuery } from '@/hooks/queries/useOrderQuery';
@@ -47,6 +48,10 @@ export default function Page() {
                     </div>
                 ))
             )}
+
+            <div className="px-5 py-6">
+                <RefundPolicy />
+            </div>
         </div>
     );
 }

--- a/apps/client/src/app/mypage/order-list/page.tsx
+++ b/apps/client/src/app/mypage/order-list/page.tsx
@@ -6,7 +6,6 @@ import Divider from '@/components/features/mypage/Divider';
 import NoItem from '@/components/features/mypage/list/NoItem';
 // import TabBar from '@/components/features/mypage/list/TabBar';
 import ProductItemByDeliveryState from '@/components/features/mypage/ProductItemByDeliveryState';
-import RefundPolicy from '@/components/features/mypage/return-form/RefundPolicy';
 import Header from '@/components/layouts/Header';
 // import { ORDER_LIST_TABS } from '@/constants/mypage';
 import { useOrderHistoryQuery } from '@/hooks/queries/useOrderQuery';
@@ -48,10 +47,6 @@ export default function Page() {
                     </div>
                 ))
             )}
-
-            <div className="px-5 py-6">
-                <RefundPolicy />
-            </div>
         </div>
     );
 }

--- a/apps/client/src/app/mypage/order-list/page.tsx
+++ b/apps/client/src/app/mypage/order-list/page.tsx
@@ -1,42 +1,52 @@
 'use client';
 
-import { useState } from 'react';
+// import { useState } from 'react';
 
 import Divider from '@/components/features/mypage/Divider';
-import TabBar from '@/components/features/mypage/list/TabBar';
+import NoItem from '@/components/features/mypage/list/NoItem';
+// import TabBar from '@/components/features/mypage/list/TabBar';
 import ProductItemByDeliveryState from '@/components/features/mypage/ProductItemByDeliveryState';
 import Header from '@/components/layouts/Header';
-import { ORDER_LIST_TABS } from '@/constants/mypage';
+// import { ORDER_LIST_TABS } from '@/constants/mypage';
+import { useOrderHistoryQuery } from '@/hooks/queries/useOrderQuery';
+import { formatDate } from '@/utils/formatDate';
 
 export default function Page() {
-    const [selectedTab, setSelectedTab] = useState(ORDER_LIST_TABS[0]!.label);
+    // const [selectedTab, setSelectedTab] = useState(ORDER_LIST_TABS[0]!.label);
+    const { data: orders } = useOrderHistoryQuery();
 
     return (
         <div>
             <Header type="title" title="주문 내역" />
-            <TabBar
+            {/* <TabBar
                 tabs={ORDER_LIST_TABS}
                 selectedTab={selectedTab}
                 onClick={(tab) => setSelectedTab(tab)}
-            />
+            /> */}
 
-            {/* <NoItem /> */}
-            {[[0, 1], [2], [3]].map((arr) => (
-                <div key={arr[0]}>
-                    <div className="space-y-4 px-5 py-6">
-                        <div className="text-headline-04">2025.04.25</div>
-                        <div className="space-y-5">
-                            {arr.map((item) => (
-                                <ProductItemByDeliveryState
-                                    key={item}
-                                    type="order"
-                                />
-                            ))}
+            {!orders || orders.length === 0 ? (
+                <NoItem />
+            ) : (
+                orders.map((order) => (
+                    <div key={order.orderId}>
+                        <div className="space-y-4 px-5 py-6">
+                            <div className="text-headline-04">
+                                {formatDate(order.orderDate)}
+                            </div>
+                            <div className="space-y-5">
+                                {order.objects.map((object) => (
+                                    <ProductItemByDeliveryState
+                                        key={object.objectId}
+                                        type="order"
+                                        object={object}
+                                    />
+                                ))}
+                            </div>
                         </div>
+                        <Divider />
                     </div>
-                    <Divider />
-                </div>
-            ))}
+                ))
+            )}
         </div>
     );
 }

--- a/apps/client/src/app/mypage/return-detail/[id]/page.tsx
+++ b/apps/client/src/app/mypage/return-detail/[id]/page.tsx
@@ -1,5 +1,4 @@
 import Divider from '@/components/features/mypage/Divider';
-import ProductItemByDeliveryState from '@/components/features/mypage/ProductItemByDeliveryState';
 import ReturnDetail from '@/components/features/mypage/return-detail/ReturnDetail';
 import ReturnPaymentSummary from '@/components/features/mypage/return-detail/ReturnPaymentSummary';
 import Header from '@/components/layouts/Header';
@@ -22,7 +21,7 @@ export default function Page() {
 
             {/* 취소 상품 */}
             <div className="space-y-5 px-5 py-6">
-                <ProductItemByDeliveryState isDetailPage type="return" />
+                {/* <ProductItemByDeliveryState isDetailPage type="return" /> */}
             </div>
 
             <Divider />

--- a/apps/client/src/app/mypage/return-form/[type]/complete/page.tsx
+++ b/apps/client/src/app/mypage/return-form/[type]/complete/page.tsx
@@ -1,4 +1,3 @@
-import OrderItem from '@/components/features/order/OrderItem';
 import Header from '@/components/layouts/Header';
 
 export default async function Page({
@@ -9,14 +8,14 @@ export default async function Page({
     const { type } = await params;
     const isCancel = type === 'cancel';
 
-    const item = {
-        totalPrice: 21000,
-        quantity: 1,
-        objectId: '1',
-        objectName: '이름',
-        imageUrl: '/banner/01.png',
-        objectPrice: 21000,
-    };
+    // const item = {
+    //     totalPrice: 21000,
+    //     quantity: 1,
+    //     objectId: '1',
+    //     objectName: '이름',
+    //     imageUrl: '/banner/01.png',
+    //     objectPrice: 21000,
+    // };
 
     return (
         <div className="grid h-dvh grid-rows-[auto_1fr_auto]">
@@ -42,7 +41,7 @@ export default async function Page({
                     <div className="text-body-01 font-semibold">
                         {isCancel ? '취소' : '환불'} 요청 상품
                     </div>
-                    <OrderItem item={item} variant="form" />
+                    {/* <OrderItem item={item} variant="form" /> */}
                     <button className="border-button-gray-regular text-body-03 w-full rounded-md border py-2">
                         취소 상세
                     </button>

--- a/apps/client/src/app/mypage/return-list/page.tsx
+++ b/apps/client/src/app/mypage/return-list/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 
-import Divider from '@/components/features/mypage/Divider';
 import TabBar from '@/components/features/mypage/list/TabBar';
 import Header from '@/components/layouts/Header';
 import { RETURN_LIST_TABS } from '@/constants/mypage';
@@ -19,22 +18,25 @@ export default function Page() {
                 onClick={(tab) => setSelectedTab(tab)}
             />
 
-            {[[0, 1], [2], [3]].map((arr) => (
+            <div className="text-body-03 fixed left-0 top-0 flex h-dvh w-dvw items-center justify-center font-normal">
+                아직 준비 준비 중인 서비스입니다.
+            </div>
+            {/* {[[0, 1], [2], [3]].map((arr) => (
                 <div key={arr[0]}>
                     <div className="space-y-4 px-5 py-6">
                         <div className="text-headline-04">2025.04.25</div>
                         <div className="space-y-5">
-                            {/* {arr.map((item) => (
+                            {arr.map((item) => (
                                 <ProductItemByDeliveryState
                                     key={item}
                                     type="return"
                                 />
-                            ))} */}
+                            ))}
                         </div>
                     </div>
                     <Divider />
                 </div>
-            ))}
+            ))} */}
         </div>
     );
 }

--- a/apps/client/src/app/mypage/return-list/page.tsx
+++ b/apps/client/src/app/mypage/return-list/page.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 
 import Divider from '@/components/features/mypage/Divider';
 import TabBar from '@/components/features/mypage/list/TabBar';
-import ProductItemByDeliveryState from '@/components/features/mypage/ProductItemByDeliveryState';
 import Header from '@/components/layouts/Header';
 import { RETURN_LIST_TABS } from '@/constants/mypage';
 
@@ -25,12 +24,12 @@ export default function Page() {
                     <div className="space-y-4 px-5 py-6">
                         <div className="text-headline-04">2025.04.25</div>
                         <div className="space-y-5">
-                            {arr.map((item) => (
+                            {/* {arr.map((item) => (
                                 <ProductItemByDeliveryState
                                     key={item}
                                     type="return"
                                 />
-                            ))}
+                            ))} */}
                         </div>
                     </div>
                     <Divider />

--- a/apps/client/src/components/features/mypage/ProductItemByDeliveryState.tsx
+++ b/apps/client/src/components/features/mypage/ProductItemByDeliveryState.tsx
@@ -10,25 +10,19 @@ import {
     ORDER_LIST_STATUS,
     RETURN_LIST_STATUS,
 } from '@/constants/deliveryState';
+import { OrderedObjectDetailInfo } from '@/schemas/order';
 import { formatPrice } from '@/utils/formatPrice';
 
 export default function ProductItemByDeliveryState({
     type,
+    object: product,
     isDetailPage = false,
 }: {
     type: 'order' | 'return';
+    object: OrderedObjectDetailInfo;
     isDetailPage?: boolean;
 }) {
     const isOrderList = type === 'order';
-
-    // 추후 props로 전달
-    const product = {
-        objectName: '이름이름이름',
-        intro: '설명설명설명설명설명설명',
-        objectPrice: 10000,
-        imageUrl: '/banner/01.png',
-        status: isOrderList ? 'PURCHASE_CONFIRMED' : 'CANCELED_REQUESTED',
-    };
 
     const deliveryStatus = isOrderList ? ORDER_LIST_STATUS : RETURN_LIST_STATUS;
     const currentDeliveryStatus = deliveryStatus.find(
@@ -103,6 +97,8 @@ export default function ProductItemByDeliveryState({
         }
     };
 
+    if (!currentDeliveryStatus) return null;
+
     return (
         <div>
             <div className="mb-2 flex items-center justify-between">
@@ -140,7 +136,7 @@ export default function ProductItemByDeliveryState({
                         {product.intro}
                     </div>
                     <div className="text-body-03 font-semibold">
-                        {formatPrice(product.objectPrice)}원
+                        {formatPrice(product.purchasePrice)}원
                     </div>
                 </div>
             </div>

--- a/apps/client/src/components/features/mypage/list/NoItem.tsx
+++ b/apps/client/src/components/features/mypage/list/NoItem.tsx
@@ -5,7 +5,7 @@ export default function NoItem() {
                 <div className="flex flex-col items-center gap-5">
                     <div className="opacity-33 h-[3.375rem] w-[3.375rem] bg-[url('/alert.svg')] bg-center bg-no-repeat" />
                     <div className="text-headline-04 font-normal">
-                        해당 상품 내역이 없습니다.
+                        상품 내역이 없습니다.
                     </div>
                 </div>
             </div>

--- a/apps/client/src/constants/deliveryState.ts
+++ b/apps/client/src/constants/deliveryState.ts
@@ -1,5 +1,10 @@
 export const ORDER_LIST_STATUS = [
     {
+        label: 'PENDING',
+        value: '주문 대기',
+        button: '',
+    },
+    {
         label: 'ORDERED',
         value: '배송 준비',
         button: '주문 취소',

--- a/apps/client/src/constants/footer.ts
+++ b/apps/client/src/constants/footer.ts
@@ -15,4 +15,8 @@ export const FOOTER_LINKS = [
         label: '개인정보처리방침',
         href: 'https://clean-archduke-51e.notion.site/22b9575b8447803095a1f9df09300e27?source=copy_link',
     },
+    {
+        label: '환불규정',
+        href: '/agreement/refund',
+    },
 ];

--- a/apps/client/src/constants/mypage.ts
+++ b/apps/client/src/constants/mypage.ts
@@ -5,10 +5,10 @@ export const MYPAGE_LINKS = [
         label: '주문 내역',
         href: '/mypage/order-list',
     },
-    {
-        label: '취소/반품 내역',
-        href: '/mypage/return-list',
-    },
+    // {
+    //     label: '취소/반품 내역',
+    //     href: '/mypage/return-list',
+    // },
     {
         label: '회원 정보 수정',
         href: '/mypage/edit',

--- a/apps/client/src/constants/mypage.ts
+++ b/apps/client/src/constants/mypage.ts
@@ -5,10 +5,10 @@ export const MYPAGE_LINKS = [
         label: '주문 내역',
         href: '/mypage/order-list',
     },
-    // {
-    //     label: '취소/반품 내역',
-    //     href: '/mypage/return-list',
-    // },
+    {
+        label: '취소/반품 내역',
+        href: '/mypage/return-list',
+    },
     {
         label: '회원 정보 수정',
         href: '/mypage/edit',

--- a/apps/client/src/schemas/order.ts
+++ b/apps/client/src/schemas/order.ts
@@ -101,13 +101,13 @@ const orderedObjectDetailInfo = z.object({
     ...placedOrderObjectInfo.omit({ stock: true }).shape,
     intro: z.string(),
     status: orderStatusEnum,
-    orderDate: z.iso.datetime(),
 });
 export type OrderedObjectDetailInfo = z.infer<typeof orderedObjectDetailInfo>;
 
 // 전체 주문 내역 조회 (/order/v1)
 export const orderHistoryUnit = z.object({
     orderId: z.uuid(),
+    orderDate: z.iso.datetime(),
     objects: z.array(orderedObjectDetailInfo),
 });
 export type OrderHistoryUnit = z.infer<typeof orderHistoryUnit>;

--- a/apps/client/src/utils/formatDate.ts
+++ b/apps/client/src/utils/formatDate.ts
@@ -1,0 +1,5 @@
+export function formatDate(dateString: string) {
+    const date = new Date(dateString);
+
+    return new Intl.DateTimeFormat().format(date);
+}


### PR DESCRIPTION
## ✨ PR Content

- 주문 내역 api 연결
- 주문 내역 api가 배송 상태별로 필터링이 안 돼서 주문 내역 내부 탭을 제거하고, 취소 내역 페이지는 준비중으로 변경했습니다.
- 주문 상세는 유저-주문 간 매칭이 안 된다는 에러가 나서 연결 안 해두었습니다
- 환불 규정이 심사에 필요해 임시로 별도 페이지를 만들어 푸터에 링크를 걸어두었습니다

## 📎 Related Issue

- #74 

## 📸 Screenshot

- 변경된 UI가 있다면 첨부해주세요!

## 🪄 To Reviewers

- 리뷰어에게 알려주고 싶은 내용이 있다면 여기에 작성해주세요!
